### PR TITLE
refactor: 関数定義方法の統一化、流れを追いやすいコード構成への変更

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -15,7 +15,6 @@
   },
   "devDependencies": {
     "@nuxtjs/eslint-config-typescript": "12.0.0",
-    "@types/color-thief-node": "^1.0.1",
     "eslint": "8.29.0",
     "eslint-plugin-nuxt": "4.0.0",
     "sass": "1.56.2",

--- a/web/src/components/CardItem.vue
+++ b/web/src/components/CardItem.vue
@@ -1,10 +1,15 @@
-<!--suppress TypeScriptCheckImport -->
 <script setup lang="ts">
 import { Buffer } from 'buffer'
-import { PropType, onMounted, ref, Ref } from 'vue'
+import { PropType, onMounted, ref } from 'vue'
 import { useFetch } from '#app'
 import { getColor, Palette } from 'color-thief-node'
 import { Item } from '@/types/types'
+
+// data
+const dataUrl = ref<string>()
+const palette = ref<Palette>()
+const gradient = ref<string>()
+const cardTitleClass = ref<string>()
 
 // props
 const props = defineProps({
@@ -17,9 +22,6 @@ const props = defineProps({
     required: true
   }
 })
-
-const gradient: Ref<string|undefined> = ref(undefined)
-const textColor: Ref<string|undefined> = ref(undefined)
 
 // methods
 const calcHeight = (item: Item) => {
@@ -37,49 +39,7 @@ const getImageUrl = (item: Item) => {
   return `https://pbs.twimg.com/media/${imageId}?format=jpg&name=small`
 }
 
-const getTargetDisplay = (item: Item) => {
-  if (props.isAnd || !item.target) {
-    return ''
-  }
-  return `by ${item.target.name} likes`
-}
-
-const getGradient = async (item: Item) => {
-  const image = new Image()
-  const imageURL = getImageUrl(item)
-  const response = await useFetch(imageURL, { responseType: 'arrayBuffer' })
-  if (!response.data) {
-    throw new Error('response.data is undefined')
-  }
-  const a = response.data.value
-  if (!a) {
-    throw new Error('a is undefined')
-  }
-  // get data url
-  const dataURL = `data:image/jpeg;base64,${Buffer.from(
-      a as any,
-      'binary'
-  ).toString('base64')}`
-  image.onload = async () => {
-    const dominantColor = await getColor(image)
-    console.log('dominantColor', dominantColor)
-    if (rgb2hsl(dominantColor) <= 0.6) {
-      textColor.value = 'text-white text-right text-subtitle-2'
-    } else {
-      textColor.value = 'text-black text-right text-subtitle-2'
-    }
-    gradient.value = `to bottom, rgba(${dominantColor}, .1), rgba(${dominantColor}, .5)`
-  }
-  console.log('dataURL', dataURL)
-  image.src = dataURL
-}
-
-// mounted
-onMounted(() => {
-  getGradient(props.item)
-})
-
-function rgb2hsl(rgb: Palette): number {
+const rgb2Lightness = (rgb: Palette): number => {
   const r = rgb[0] / 255
   const g = rgb[1] / 255
   const b = rgb[2] / 255
@@ -89,17 +49,84 @@ function rgb2hsl(rgb: Palette): number {
 
   return (max + min) / 2
 }
+
+const getTargetDisplay = (item: Item) => {
+  if (props.isAnd || !item.target) {
+    return ''
+  }
+  return `by ${item.target.name} likes`
+}
+
+const isArrayBuffer = (value: any): value is ArrayBuffer => {
+  return value instanceof ArrayBuffer
+}
+
+const getDataUrl = async (url: string) => {
+  const response = await useFetch<ArrayBuffer>(url, { responseType: 'arrayBuffer' })
+  if (!response.data) {
+    throw new Error('response.data is undefined')
+  }
+  const data = response.data.value
+  if (!data) {
+    throw new Error('data is undefined')
+  }
+  if (!isArrayBuffer(data)) {
+    throw new Error('data is not ArrayBuffer')
+  }
+  // get data url
+  const base64 = Buffer.from(data).toString('base64')
+  const dataURL = `data:image/jpeg;base64,${base64}`
+  return dataURL
+}
+
+const getPalette = async (dataUrl: string) => {
+  const image = new Image()
+  return await new Promise<Palette>((resolve, reject) => {
+    image.onload = () => {
+      resolve(getColor(image))
+    }
+    image.onerror = (error) => {
+      reject(error)
+    }
+    image.src = dataUrl
+  })
+}
+
+const getCardTitleClass = (palette: Palette) => {
+  const commonClasses = 'text-right text-subtitle-2'
+  const lightness = rgb2Lightness(palette)
+  // 0.6以上なら白、0.6未満なら黒
+  return lightness >= 0.6 ? `${commonClasses} text-white` : `${commonClasses} text-black`
+}
+
+const getGradient = (palette: Palette) => {
+  // Palette.toString() は、"r, g, b" の形式っぽい
+  return `to bottom, rgba(${palette}, .1), rgba(${palette}, .5)`
+}
+
+onMounted(async () => {
+  // ツイートの画像 URL
+  const imageURL = getImageUrl(props.item)
+  // 画像を Data URL に変換
+  dataUrl.value = await getDataUrl(imageURL)
+  // パレットを取得
+  palette.value = await getPalette(dataUrl.value)
+  // カードタイトルのクラスを作成
+  cardTitleClass.value = getCardTitleClass(palette.value)
+  // gradientを作成
+  gradient.value = getGradient(palette.value)
+})
 </script>
 
 <template>
   <v-card width="240px">
     <v-img
       :height="calcHeight(item)"
-      :src="getImageUrl(item)"
+      :src="dataUrl"
       class="align-end"
       :gradient="gradient"
     >
-      <v-card-title :class="textColor">
+      <v-card-title :class="cardTitleClass">
         {{ getTargetDisplay(item) }}
       </v-card-title>
       <template #placeholder>

--- a/web/src/types/color-thief-node.d.ts
+++ b/web/src/types/color-thief-node.d.ts
@@ -1,0 +1,21 @@
+declare module 'color-thief-node' {
+  export type Palette = [red: number, green: number, blue: number];
+
+  /**
+   * Use the median cut algorithm provided by quantize.js to cluster similar
+   * colors and return the base color from the largest cluster.
+   */
+  export function getColor(sourceImage: HTMLImageElement, quality?: number): Palette;
+
+  /**
+   * Use the median cut algorithm provided by quantize.js
+   * to cluster similar colors.
+   */
+  export function getPaletteFromURL(URL: string, colorCount?: number, quality?: number): Promise<Palette[]>;
+
+  /**
+   * Use the median cut algorithm provided by quantize.js
+   * to cluster similar colors.
+   */
+  export function getColorFromURL(imageURL: string, quality?: number): Promise<Palette>;
+}

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -775,11 +775,6 @@
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"
   integrity sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==
 
-"@types/color-thief-node@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@types/color-thief-node/-/color-thief-node-1.0.1.tgz#851a82b48a5560e4d2c051324e42c21a25e5802c"
-  integrity sha512-UU2pvvjtxvugMdCpoG7If9EqbaeITyczSXymIA/h/Quzbf4HwvT1uBKDG0R42jzHlHGOsRqCRb+RP5Kj1RIBaQ==
-
 "@types/eslint@^8.4.5":
   version "8.4.10"
   resolved "https://registry.yarnpkg.com/@types/eslint/-/eslint-8.4.10.tgz#19731b9685c19ed1552da7052b6f668ed7eb64bb"


### PR DESCRIPTION
- #82 のプルリクエストをもとに、関数定義など適切な方法に置き換えました。
- 流れの追いにくい一部の処理（データURL関連）は別の関数に分離するなど、流れを追いやすいコードになるようにリファクタリングしました。
- `color-thief-node` の `getColor` メソッドは `Promise<Palette>` ではなく `Palette` を返すことが判明したため、独自の `d.ts` 型定義ファイルを設置して正しくサジェストするようにしました。また DefinitelyTyped にプルリクエストを提出しました: [DefinitelyTyped/DefinitelyTyped#63651](https://togithub.com/DefinitelyTyped/DefinitelyTyped/pull/63651)