### PR TITLE
feat: APIサイドでページネーション

### DIFF
--- a/crawler/src/endpoints/api-router.ts
+++ b/crawler/src/endpoints/api-router.ts
@@ -71,7 +71,10 @@ export class ApiRouter extends BaseRouter {
     })
 
     if (filterType === 'or' || filterType === undefined || !targetIds) {
-      reply.send(this.pagination(items, offset, limit))
+      reply.send({
+        items: this.pagination(items, offset, limit),
+        total: items.length,
+      })
       return
     }
     // 同一ツイートIDが出てくる回数をカウントする。targets指定数と同じなら残す
@@ -99,7 +102,10 @@ export class ApiRouter extends BaseRouter {
           index
         )
       })
-    reply.send(this.pagination(filteredItems, offset, limit))
+      reply.send({
+        items: this.pagination(filteredItems, offset, limit),
+        total: items.length,
+      })
   }
 
   pagination<T>(

--- a/crawler/src/endpoints/api-router.ts
+++ b/crawler/src/endpoints/api-router.ts
@@ -6,12 +6,12 @@ import { DBTarget } from '@/entities/targets'
 import { DBTweet } from '@/entities/tweets'
 
 interface ImagesQuery {
-  targetIds?: string
+  targetIds?: string[]
   type?: 'or' | 'and'
   offset?: number
   limit?: number
   tags?: string[]
-  vieweds?: string[]
+  vieweds?: number[]
 }
 
 export class ApiRouter extends BaseRouter {
@@ -20,7 +20,6 @@ export class ApiRouter extends BaseRouter {
       (fastify, _, done) => {
         fastify.get('/targets', this.routeGetTargets.bind(this))
         fastify.get('/tags', this.routeGetTags.bind(this))
-        fastify.get('/images', this.routeGetImages.bind(this))
         fastify.post('/images', this.routePostImages.bind(this))
         done()
       },
@@ -60,15 +59,6 @@ export class ApiRouter extends BaseRouter {
     reply.send(tagsWithCount)
   }
 
-  async routeGetImages(
-    request: FastifyRequest<{
-      Querystring: ImagesQuery
-    }>,
-    reply: FastifyReply
-  ): Promise<void> {
-    await this.getImages(request.query, reply)
-  }
-
   async routePostImages(
     request: FastifyRequest<{
       Body: ImagesQuery
@@ -80,7 +70,7 @@ export class ApiRouter extends BaseRouter {
 
   async getImages(query: ImagesQuery, reply: FastifyReply) {
     // targets query
-    const targetIds = query.targetIds ? query.targetIds.split(',') : undefined
+    const targetIds = query.targetIds
     const filterType = query.type
     const offset = query.offset
     const limit = query.limit
@@ -114,7 +104,7 @@ export class ApiRouter extends BaseRouter {
     const vieweds = query.vieweds
     if (vieweds) {
       items = items.filter((item) => {
-        return !vieweds.includes(item.tweet.tweetId)
+        return !vieweds.includes(item.rowId)
       })
     }
 

--- a/crawler/src/endpoints/api-router.ts
+++ b/crawler/src/endpoints/api-router.ts
@@ -87,6 +87,9 @@ export class ApiRouter extends BaseRouter {
             }
           })
         : undefined,
+      order: {
+        createdAt: 'DESC',
+      },
     })
     let items = results.map((item) => {
       return {

--- a/crawler/src/endpoints/api-router.ts
+++ b/crawler/src/endpoints/api-router.ts
@@ -102,10 +102,10 @@ export class ApiRouter extends BaseRouter {
           index
         )
       })
-      reply.send({
-        items: this.pagination(filteredItems, offset, limit),
-        total: items.length,
-      })
+    reply.send({
+      items: this.pagination(filteredItems, offset, limit),
+      total: items.length,
+    })
   }
 
   pagination<T>(

--- a/mock-api/src/endpoint.ts
+++ b/mock-api/src/endpoint.ts
@@ -12,7 +12,7 @@ export class EndPoints {
     this.fastify.register(
       (fastify, _, done) => {
         fastify.get('/targets', this.routeGetTargets.bind(this))
-        fastify.get('/images', this.routeGetImages.bind(this))
+        fastify.post('/images', this.routePostImages.bind(this))
         done()
       },
       { prefix: '/api' }
@@ -32,15 +32,14 @@ export class EndPoints {
     reply.send(response.data)
   }
 
-  async routeGetImages(
+  async routePostImages(
     request: FastifyRequest,
     reply: FastifyReply
   ): Promise<void> {
-    const queries = request.query
-
-    const response = await axios.get('https://likes.amatama.net/api/images', {
-      params: queries,
-    })
+    const response = await axios.post(
+      'https://likes.amatama.net/api/images',
+      request.body
+    )
     if (response.status !== 200) {
       reply.code(500)
       reply.send({ error: 'Internal Server Error' })

--- a/web/src/app.vue
+++ b/web/src/app.vue
@@ -229,7 +229,7 @@ onMounted(async () => {
   <v-app>
     <v-main>
       <TheHeader :items="items" :targets="targets" :loading="loading" />
-      <v-pagination v-model="page" :length="Math.ceil(getItems.length / settings.itemPerPage)" class="my-3" :disabled="loading" />
+      <v-pagination v-model="page" :length="Math.ceil(total / settings.itemPerPage)" class="my-3" :disabled="loading" />
       <v-container v-if="getItems.length === 0 && !loading">
         <v-card>
           <v-card-text class="text-h6 text-center my-3">

--- a/web/src/app.vue
+++ b/web/src/app.vue
@@ -7,7 +7,10 @@ import { useTwitterStore } from './store/twitter'
 import { useSnackbarStore } from './store/snackbar'
 
 type TargetsApiResponse = Target[]
-type ImagesApiResponse = Item[]
+type ImagesApiResponse = {
+  items: Item[]
+  total: number
+}
 
 const config = useRuntimeConfig()
 
@@ -22,11 +25,13 @@ const viewedIds = [...viewedStore.getRowIds]
 
 // --- data
 /** アイテム一覧 */
-const items = ref<ImagesApiResponse>([])
+const items = ref<Item[]>([])
 /** すべてのターゲット */
 const targets = ref<Target[]>([])
 /** 現在のページ */
 const page = ref(1)
+/** 総件数 */
+const total = ref(0)
 /** ローディング中かどうか */
 const loading = ref(true)
 /** 連続して選択が更新された時用のタイマー */
@@ -120,10 +125,11 @@ const fetchItems = async (): Promise<void> => {
   if (!response || !response.data.value) {
     return
   }
-  const results = response.data.value.sort(
+  const results = response.data.value.items.sort(
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )
   items.value = results
+  total.value = response.data.value.total
   loading.value = false
 }
 

--- a/web/src/components/SettingsModal.vue
+++ b/web/src/components/SettingsModal.vue
@@ -8,7 +8,13 @@ const isOpen = ref(false)
 // --- settings computed
 const itemPerPage = computed({
   get: () => settings.itemPerPage,
-  set: (val) => settings.setItemPerPage(val)
+  set: (val) => {
+    // stringがくる可能性がある
+    if (typeof val === 'string') {
+      val = parseInt(val)
+    }
+    settings.setItemPerPage(val)
+  }
 })
 const maxCols = computed({
   get: () => settings.magicGrid.maxCols,

--- a/web/src/components/TagSelector.vue
+++ b/web/src/components/TagSelector.vue
@@ -3,9 +3,16 @@
 <script setup lang="ts">
 import { Item } from '../types/types'
 
+type TagsApiResponse = {
+  tag: string
+  count: number
+}[]
+
+const config = useRuntimeConfig()
+
 // --- emits
 interface Emits {
-  (e: 'updated', newValue: string): void
+  (e: 'updated', newValues: string[]): void
 }
 const emit = defineEmits<Emits>()
 
@@ -31,13 +38,20 @@ watch(itemsRef, () => {
 })
 
 watch(selected, () => {
-  emit('updated', selected.value.join('\t'))
+  emit('updated', selected.value)
 })
 
 // --- mounted
-onMounted(() => {
-  tags.value = props.items.map((tweet) => tweet.tweet.tags).flat().filter((tag, index, self) => self.indexOf(tag) === index)
-  emit('updated', selected.value.join('\t'))
+onMounted(async () => {
+  const response = await useFetch<TagsApiResponse>(
+    `${config.public.apiBaseURL}/tags`
+  )
+  if (!response.data.value || response.error.value) {
+    alert(`Error: "Failed to fetch tags: ${response.error.value}`)
+    return
+  }
+  tags.value = response.data.value.map((tag) => tag.tag)
+  emit('updated', selected.value)
 })
 </script>
 

--- a/web/src/components/TheHeader.vue
+++ b/web/src/components/TheHeader.vue
@@ -5,16 +5,21 @@ import { useDisplay } from 'vuetify'
 import { useSettingsStore } from '../store/settings'
 import { useSnackbarStore } from '../store/snackbar'
 import { useTwitterStore } from '../store/twitter'
-import { useViewedStore } from '../store/viewed'
 import { Item, Target } from '../types/types'
 import TagSelector from './TagSelector.vue'
 
 /// --- store
 const config = useRuntimeConfig()
-const viewedStore = useViewedStore()
 const snackbarStore = useSnackbarStore()
 const settings = useSettingsStore()
 const twitterStore = useTwitterStore()
+
+// --- emit
+interface Emits {
+  /** すべてのアイテムを既読にする */
+  (e: 'allViewed'): void
+}
+const emit = defineEmits<Emits>()
 
 // --- settings computed
 const isAnd = computed({
@@ -59,8 +64,8 @@ const props = defineProps<{
 // --- methods
 
 /** 選択中タグをアップデートする */
-const updatedSelectTags = (val: string): void => {
-  selectTags.value = val.split('\t').filter((v) => v !== '')
+const updatedSelectTags = (val: string[]): void => {
+  selectTags.value = val.filter((v) => v !== '')
 }
 
 /** すべてのアイテムを既読にする */
@@ -68,12 +73,7 @@ const allViewed = (): void => {
   if (!confirm('すべてのアイテムを既読にしますか？')) {
     return
   }
-  viewedStore.addAll(props.items.map((item) => item.rowId))
-
-  snackbarStore.start('すべてのアイテムを既読にしました。3秒後に再読み込みします。', 'green')
-  setTimeout(() => {
-    location.reload()
-  }, 3000)
+  emit('allViewed')
 }
 
 /** ログイン/ログアウト */


### PR DESCRIPTION
- `/api/images` に `offset` と `limit` クエリを追加
- `/api/images` が返す形式の変更: 配列でアイテムを返していたが、今回からオブジェクトで返し items の値にアイテムを、total に検索でマッチするすべてのアイテム数を返す
- 渡すパラメータ数の関係上、GETでは賄えないと判断したので `/api/images` のリクエストメソッドをPOSTのみに変更
- `/api/tags` エンドポイントの追加

## TODO

- [x] フロントエンド側の対応
   - ページネーションの変更
   - ハッシュタグ一覧を `/api/tags` エンドポイントから拾う